### PR TITLE
Fix mosh install and use newest version of dokku.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.31.1
 docopt==0.6.2
-Fabric==1.9.0
+Fabric==1.10.1
 giturlparse.py==0.0.5
 pybars==0.0.4
 tld==0.6.4

--- a/riker/api.py
+++ b/riker/api.py
@@ -489,10 +489,9 @@ class BaseInstance(CachedObject):
     # @synchronize('install_mosh.lock', is_remote=True)
     def install_mosh(self):
         log('info', 'Installing mosh', show_header=True)
-        sudo('apt-get update -y')
-        sudo('apt-get install -y python-software-properties')
         sudo('add-apt-repository -y ppa:keithw/mosh')
         sudo('apt-get update -y')
+        sudo('apt-get install -y python-software-properties')
         sudo('apt-get install -y mosh')
 
     # @synchronize('configure_nginx.lock', is_remote=True)

--- a/riker/api.py
+++ b/riker/api.py
@@ -16,7 +16,7 @@ from boto.ec2.elb import HealthCheck
 from boto.ec2.autoscale import LaunchConfiguration
 from boto.ec2.autoscale import AutoScalingGroup
 from boto.ec2.elb.attributes import ConnectionDrainingAttribute
-from fabric.api import task, run, local, env, sudo, lcd, execute, put
+from fabric.api import task, run, local, env, sudo, lcd, execute, put, settings
 from fabric.contrib.files import exists, append, sed
 from fabric.operations import reboot
 import giturlparse
@@ -30,7 +30,7 @@ from utils import poll_for_condition, log, first
 from retry import synchronize
 
 import fabric
-fabric.state.output.everything = False
+fabric.state.output.everything = True
 
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
 s3_website_regions = {
@@ -534,6 +534,7 @@ def terminate_instances(instance_ids):
 def get_config(app, env):
     config_path = get_config_path(env)
     cfg_path = join(config_path, '{}.env'.format(app))
+    log('info', "looking for config at cfg_path: {}".format(cfg_path))
     try:
         with open(cfg_path) as f:
             cfg = f.read().replace("\n", ' ').strip()

--- a/riker/api.py
+++ b/riker/api.py
@@ -475,8 +475,8 @@ class BaseInstance(CachedObject):
         https://github.com/progrium/dokku
         """
         log('info', 'Installing dokku', show_header=True)
-        run('curl -sL https://raw.github.com/progrium/dokku/v0.2.3/bootstrap.sh > ~/dokku-install.sh')
-        sudo('DOKKU_TAG=v0.2.3 bash ~/dokku-install.sh; rm -f ~/dokku-install.sh')
+        run('curl -sL https://raw.github.com/progrium/dokku/v0.3.15/bootstrap.sh > ~/dokku-install.sh')
+        sudo('DOKKU_TAG=v0.3.15 bash ~/dokku-install.sh; rm -f ~/dokku-install.sh')
         put('~/.ssh/id_rsa.pub', '~', mirror_local_mode=True)
         run('cat ~/id_rsa.pub | sudo sshcommand acl-add {} ubuntu'.format(config['deploy_user']))
         run('rm ~/id_rsa.pub')
@@ -489,6 +489,7 @@ class BaseInstance(CachedObject):
     # @synchronize('install_mosh.lock', is_remote=True)
     def install_mosh(self):
         log('info', 'Installing mosh', show_header=True)
+        sudo('apt-get update -y')
         sudo('apt-get install -y python-software-properties')
         sudo('add-apt-repository -y ppa:keithw/mosh')
         sudo('apt-get update -y')

--- a/riker/api.py
+++ b/riker/api.py
@@ -16,7 +16,7 @@ from boto.ec2.elb import HealthCheck
 from boto.ec2.autoscale import LaunchConfiguration
 from boto.ec2.autoscale import AutoScalingGroup
 from boto.ec2.elb.attributes import ConnectionDrainingAttribute
-from fabric.api import task, run, local, env, sudo, lcd, execute, put, settings
+from fabric.api import task, run, local, env, sudo, lcd, execute, put
 from fabric.contrib.files import exists, append, sed
 from fabric.operations import reboot
 import giturlparse

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "boto == 2.31.1",
         "docopt == 0.6.2",
-        "Fabric == 1.9.0",
+        "Fabric == 1.10.1",
         "giturlparse.py == 0.0.5",
         "pybars==0.0.4",
         "tld==0.6.4"


### PR DESCRIPTION
I was able to get Riker to work for a few deploys after some tinkering.

apt-get install python-software-properties was failing when I first tried it.  Apt needed an update first for it to install properly.

Also, I was getting nginx errors on my deployed instances until I updated the version of dokku installed on those instances.

These two changes allowed everything to complete successfully.
